### PR TITLE
Document the export feature!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.0.1
+- Added: old example emails are in `docs/emails/`
+- Changed: documentation now explains the built-in export feature
+- Changed: documentation is clearer in-app for pref cards
+- Fixed: properly check for `?post_type=` query string to avoid errors on Posts page
+
 # 1.0
 - Added: changelog
 - Added: can now customize the registration confirmation message

--- a/How to run auditions.md
+++ b/How to run auditions.md
@@ -24,6 +24,8 @@ The theme should warn you if you've set it up incorrectly (not using a static fr
 
 Many of the pages are blank expect for some text and a **shortcode** (text surrounded by brackets---like `[acac_prefs]`). These are codes that **ACAC Features** uses to render auditionee-facing forms, like the pref cards and registration pages.
 
+For more documentation about the theme itself, see [the theme's repo](https://github.com/citelao/acac-theme).
+
 ### ACAC Features
 
 The **ACAC Features** necessary to run auditions are written entirely separately from the **ACAC Theme**. Most of the code handles internal administration pages used for callback selection and logistics.
@@ -36,10 +38,12 @@ It creates several new content types:
 
 It adds a `Manage Auditions` preference pane for all administrators.
 
-It also registers two shortcodes for rendering auditionee-accessible forms:
+It also registers two [shortcodes](https://kapeli.com/dash_share?docset_file=WordPress&docset_name=WordPress&path=developer.wordpress.org/plugins/shortcodes/index.html&platform=wordpress&repo=Main&source=developer.wordpress.org/plugins/shortcodes/) for rendering auditionee-accessible forms:
 
 - `acac_registration`
 - `acac_prefs`
+
+Each part is explained in detail here.
 
 ## The auditions process
 
@@ -49,21 +53,21 @@ Audtions are complex, but the webmaster's job is fairly straightforward.
 
 Get the system ready to handle auditionees registering.
 
-You will receive emails throughout the day from people who messed up registration. You and anyone with `administrator` user role can edit auditionee data manually by clicking any name.
+You will receive emails throughout the day from people who messed up registration. You and anyone with the `administrator` [user role](https://kapeli.com/dash_share?docset_file=WordPress&docset_name=WordPress&path=codex.wordpress.org/Roles_and_Capabilities.html&platform=wordpress&repo=Main&source=codex.wordpress.org/Roles_and_Capabilities) can edit auditionee data manually by clicking any name.
 
-1. (Delete old auditionees?)
+1. (Delete old auditionees? This may help when emailing all auditonees.)
 2. Add new a cappella groups
-	1. Add each new group as a new (Wordpress) user.
-	2. Set their role to `author`.
-	3. Add a new `Group` for this a cappella group (in the `Groups` menu).
-	4. Set this `Group`'s author to the newly-created author. This lets this user (and only this user and administrators like you) access this group-management page.
+    1. Add each new group as a new (Wordpress) user.
+    2. Set their role to `author`.
+    3. Add a new `Group` for this a cappella group (in the `Groups` menu).
+    4. Set this `Group`'s author to the newly-created author. This lets this user (and only this user and administrators like you) access this group-management page.
 3. In the `Manage Auditions` menu on the Wordpress admin (`acac.wustl.edu/wp-admin`), configure the callback dates so that new auditionees are prompted to list conflicts for the right days.
 4. In the same menu, set the registration subject and message that appear in their confirmation email. You can use shortcodes (like `[first_name]`) to include registration information in the response.
 5. In the same menu, set the auditions stage to stage 1---allow registration, but don't let groups view callbacks.
-5. Customize the registration form page as needed (it exists as a standard Wordpress page; the content should include the shortcode `[acac_registration]` to render the registration form).
-6. Test your newly written registration confirmation email and registration process by doing a test registration. The site uses the notoriously unreliable `wp_mail` function to send email, but this can be made very reliable by using something like the `WP Mail SMTP` plugin. It should already be configured on the main website, but otherwise you will have to set it up to send from `acac@su.wustl.edu`, for example.
-7. Share the registration URL with all the groups (`acac.wustl.edu/register`); make sure that they know to force new auditionees to register. There is a sample instructional email included in `docs/Instructions for groups.md`. There are some notes to you (`Dev note`s) that you can remove.
-8. Reset passwords for all the groups that forgot them.
+6. Customize the registration form page as needed (it exists as a standard Wordpress page; the content should include the shortcode `[acac_registration]` to render the registration form).
+7. Test your newly written registration confirmation email and registration process by doing a test registration. The site uses the notoriously unreliable `wp_mail` function to send email, but this can be made very reliable by using something like the `WP Mail SMTP` plugin. It should already be configured on the main website, but otherwise you will have to set it up to send from `acac@su.wustl.edu`, for example.
+8. Share the registration URL with all the groups (`acac.wustl.edu/register`); make sure that they know to force new auditionees to register. There is a sample instructional email included in `docs/Instructions for groups.md`. There are some notes to you (at the top) that you can remove.
+9. Reset passwords for all the groups that forgot them.
 
 ### Step 2. Schedule callbacks
 
@@ -71,23 +75,33 @@ After preliminary auditions finish, it is now time to help the groups schedule c
 
 1. Hopefully all the groups have entered their callbacks on their `Group`'s page. If they haven't, make sure they do that.
 2. In the `Manage Auditions` menu, set the auditions stage to stage 2---you want to close registration, generate pref cards, and allow groups to view callbacks.
-3. Export the auditionees so ACAC can view conflict information and callback counts. There is no in-app way to do this, so I did this:
-	1. Export all auditionees to CSV (using the `All Export` plugin).
-	2. Edit the CSV (in Google Docs or Excel) to remove unneccessary columns (like pref card ID).
-	3. Let people filter and sort the columns (so people can sort by callback number, etc).
-	4. Share this Google Doc with ACAC. It is not your job to physically schedule callbacks or notify auditionees of their times. Thank God.
+3. Export the auditionees so ACAC can view conflict information and callback counts. There is no in-app way for groups to view conflict information, so I recommend this:
+    1. Export all auditionees to CSV.
+        1. On the `Auditionees` page, at the top right, click `Screen Options`.
+        2. Change the `Number of items per page` to something larger than the number of auditionees.
+        3. Select all auditionees.
+        4. In the `Bulk Actions` dropdown menu, select `Export`, then `Apply`.
+    2. This will export *all* "useful" information about auditionees---including information that the groups shouldn't see! Edit the CSV (in Google Docs or Excel) to remove unneccessary columns (like pref card "key").
+    3. Let people filter and sort the columns (so people can sort by callback number, etc).
+    4. Share this Google Doc with ACAC. It is not your job to physically schedule callbacks or notify auditionees of their times. Thank God.
 4. Export the auditionees to MailChimp. Again, no easy way.
-	1. Export all auditionees to CSV (as before).
-	2. To make it a little prettier, I edited all the list of called-back groups to be a comma-separated list (`Mosaic Whispers, Aristocats, and Stereotypes`) using a formula, but that is wholly unneccessary. You may need to change the name from IDs to actual group names (you can find the ID for a group in the URL on the edit page).
-	3. Upload as a list to our MailChimp account. When uploading, ensure you load *callback count*, *called-back groups*, and *pref card ID* as variables. MailChimp has good documentation on this.  Make sure you create the proper MERGE TAGS in List>Settings>Merge Fields. **Note:** the pref card ID is just an *ID*, not a URL. The URL is traditionally `acac.wustl.edu/prefs?key=ID_HERE`---check out the old drafts.
-	4. Draft a rejection email, a single-callback email, and a multiple-callbacks email. Old versions should be viewable on the site. Test these several times and ensure variable-replacement works (I did it wrong twice).
-	5. Send the rejection email to all folks with `0` callbacks, the single-callback email to all folks with `1` callback, and the multiple-callbacks email to all folks with `>1` callback.
+    1. Export all auditionees to CSV (as before). Note that the export has several very important columns---including  *callback count*, *called-back groups* (in a comma-separated list), and *pref card ID*.
+    2. Upload as a list to our MailChimp account. When uploading, ensure you load *callback count*, *called-back groups*, and *pref card ID* as variables. MailChimp has good documentation on this.  Make sure you create the proper MERGE TAGS in List>Settings>Merge Fields. **Note:** the pref card ID is just an *ID*, not a URL. The URL is traditionally `acac.wustl.edu/prefs?key=ID_HERE`---check out the old drafts.
+    3. Draft a rejection email, a single-callback email, and a multiple-callbacks email. The versions I used originally are in the `docs/emails/` folder, and old versions should be viewable on MailChimp. Test these several times and ensure variable-replacement works (I did it wrong twice).
+    4. Send the rejection email to all folks with `0` callbacks, the single-callback email to all folks with `1` callback, and the multiple-callbacks email to all folks with `>1` callback.
 
 ### Step 3. Handling preferences
 
 Callback lists are published, emails are out, and people want to start filling out their pref cards. Nothing for you to do! Yay!
 
-You will be getting emails throughout the day from people who messed up their forms. **You don't have to update their preferences manually!** If you find them in the `Auditionees` list, you can edit their data and *uncheck* the "Has filled out pref card" checkbox. If you save this change, they will be able to fill out a new pref card. 
+You will be getting emails throughout the day from people who messed up their forms. **You don't have to update their preferences manually!** This is important ethically since it ensures that **you do not see their preferences early**.
+
+To allow *auditionees* to modify their preference card if they messed it up:
+
+1. Find them in the `Auditionees` list.
+2. Click their name to edit them.
+3. *Uncheck* the `Preferences Submitted` checkbox (`Checked if the auditionee has submitted their preferences.`).
+4. Save this change. Once you do, they will be able to fill out a new pref card.
 
 ### Step 4. Draft time
 
@@ -97,23 +111,24 @@ Undoubtedly my favorite time in a-cappella-world, it's time to close preferences
 2. In the royal draft hall, login to the ACAC website on whatever computer Rohan wants to use as the drafting machine.
 3. One-by-one, go to each group's page and add the inductees to the group's "accepted" list. You can also go to an auditionee's page and change their "accepted" group manually.
 4. Export the final lists to MailChimp. What fun!
-	1. Same deal as before, export to CSV
-	2. Make sure you grab the *accepted group* field this time.
-	3. Draft the acceptance and rejection emails. Old versions should be on MailChimp. Test test test.
-	4. Send the emails appropriately (schedule for 8AM the next day)!
+    1. Same deal as before, export to CSV.
+    2. Make sure you grab the *accepted group* field this time.
+    3. Draft the acceptance and rejection emails. Old versions should be on MailChimp (and originals in `docs/emails/`). Test test test.
+    4. Send the emails appropriately (schedule for 8AM the next day)!
 5. YOU'RE DONE! Close auditions in the `Manage Auditions` page. Purge all memories of this from your mind.
 
-## Technical stuff
+## Shortcodes
 
-Nothing I can think of atm.
+As mentioned above, this plugin adds two [shortcodes](https://kapeli.com/dash_share?docset_file=WordPress&docset_name=WordPress&path=developer.wordpress.org/plugins/shortcodes/index.html&platform=wordpress&repo=Main&source=developer.wordpress.org/plugins/shortcodes/) for rendering auditionee-accessible forms:
+
+- `acac_registration`
+- `acac_prefs`
+
+If you add them to any page (`[acac_registration]`, for example), Wordpress will put the appropriate form (registration or pref card) on the page. These forms will only work during the appropriate auditions phase. Otherwise, they will just say something like, "Audition registration is closed at this time. Sorry!"
+
+## Songboard
 
 There is a songboard and it works, I just haven't added the old songs.
-
-## TODO
-
-- [x] Hardcoded registration email (with hardcoded dates uhoh)
-- [-] Make a deserializer PHP program for ACAC auditionees
-- [ ] Debug the accepted group dropdown (why is it empty on Chloe's computer?)
 
 ## Links
 

--- a/How to run auditions.md
+++ b/How to run auditions.md
@@ -9,16 +9,18 @@ If any part of this guide is unclear or incorrect, please contact Ben Stolovitz 
 
 This guide should give a step-by-step guide to running a cappella auditions *and* provide a brief technical overview of the systems at play.
 
-The ACAC website consists of a standard Wordpress install plus two custom plugins:
+The ACAC website consists of a standard Wordpress install plus two custom add-ons (one plugin and one theme):
 
 1. ACAC Theme
 2. ACAC Features
 
 ### ACAC Theme
 
-The **ACAC Theme** is a basic Wordpress theme; it makes the pages you write look like ACAC pages. 
+The **ACAC Theme** is a basic Wordpress theme; it makes the pages you write look like ACAC pages.
 
-It has custom behavior on the home page: instead of displaying the page content (where you would normally write a page), it supports several arbitrary *sections*. If you try editing the page, you will see below the WYSIWYG editor a form to edit the sections in use. They support HTML, which I use to make the buttons look pretty.
+It has custom behavior on the home page: instead of displaying the page content (where you would normally write a page), it supports several arbitrary *sections*. If you try editing the page, you will see a form to edit the sections in use, below the WYSIWYG editor. They support HTML, which I use to make the buttons look pretty.
+
+The theme should warn you if you've set it up incorrectly (not using a static front page, etc).
 
 Many of the pages are blank expect for some text and a **shortcode** (text surrounded by brackets---like `[acac_prefs]`). These are codes that **ACAC Features** uses to render auditionee-facing forms, like the pref cards and registration pages.
 

--- a/docs/Exporting data for MailChimp.md
+++ b/docs/Exporting data for MailChimp.md
@@ -1,0 +1,48 @@
+These are SQL queries I used to export data manually.
+
+For most export, you can use the built-in bulk action (Auditionees > Bulk Actions > Export).
+
+# Filtering for different-table-stored data
+
+This works for the list of callbacks by auditionee.
+
+I got a list of all callbacks by auditionee:
+
+```sql
+SELECT a.`ID`,
+	GROUP_CONCAT(g.`p2p_from` SEPARATOR ', ')
+FROM wp_posts a
+LEFT JOIN wp_p2p g ON g.`p2p_to` = a.`ID`
+WHERE a.post_type = "acac_auditionee"
+GROUP BY a.ID
+```
+
+Aligned those IDs with the export IDs, pasted them into a separate sheet. Added them to the real sheet:
+
+`=VLOOKUP(G2,Callbacks!A:B,2,TRUE)`
+
+Where `G2` is the auditionee's ID column, `Callbacks!A:B` is the sheet with the exported data, in the format `Auditionee ID`, `Group IDs` (simple copy-paste from Sequel Pro).
+
+Then I used find and replace manually from the list of group IDs I found on the website (look at the URLs for each group edit page).
+
+Then I used a nice hacky way to get group count:
+
+```excel
+=IF(ISBLANK(E2), 0, COUNTA(SPLIT(E2, ",", FALSE, TRUE)))
+```
+
+`E2` is the callback groups column for the current auditionee.
+
+---
+
+# Filtering for locally-stored data
+
+This works for anything stored in the auditionee itself (so not callbacks):
+
+I filtered in sublime by regex: `i:\d*;s:\d*:"(\d*)";`
+
+Then I replaced with the first capture followed by a comma: `$1, `
+
+Then I stripped trailing commas: `, $` replace with ``.
+
+Then I took the list of group IDs I manually found and did a manual find/replace in Sublime

--- a/docs/Instructions for groups.md
+++ b/docs/Instructions for groups.md
@@ -1,10 +1,17 @@
+This is the note I sent to all groups before auditions started.
+
+Every group should have a group account setup, but if they don't, you need to set one up for them.
+
+* **If a group has an account**: they do not need the **Action Required** step.
+* **If a group does not have an account**: they need to follow the **Action Required** step (and you have to setup an account for them).
+
+---
+
 Hello everyone!
 
 The ACAC website is green!
 
 # ACTION REQUIRED
-
-(Dev note: this action is only necessary if groups do not have accounts)
 
 Send me one email account for your group so I can make a website account.
 

--- a/docs/emails/ACAC Acceptance (multiple).rtf
+++ b/docs/emails/ACAC Acceptance (multiple).rtf
@@ -1,0 +1,87 @@
+{\rtf1\ansi\ansicpg1252\cocoartf1504\cocoasubrtf810
+{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+{\*\expandedcolortbl;;}
+{\*\listtable{\list\listtemplateid1\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{decimal\}.}{\leveltext\leveltemplateid1\'02\'00.;}{\levelnumbers\'01;}\fi-360\li720\lin720 }{\listname ;}\listid1}}
+{\*\listoverridetable{\listoverride\listid1\listoverridecount0\ls1}}
+\margl1440\margr1440\vieww13460\viewh16580\viewkind0
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\fs24 \cf0 Hello \{firstname\},\
+\
+Congratulations! You have been offered callbacks for several a cappella groups at Wash U!\
+\
+
+\b Information: the callbacks\
+\
+
+\b0 Your callbacks are with:\
+\
+\{groups\}\
+\
+Be prepared for emails with further instructions from them sometime today.\
+\
+These 
+\i callbacks 
+\i0 are 
+\b nonbinding 
+\b0 in any way: if you would prefer not to attend any, contact that group. If you attend any, but decide you would rather not join that group if accepted, you 
+\i do not have to
+\i0 . That is what your preference card is for:\
+\
+
+\b Action: your preference card\
+\
+
+\b0 \{prefcard link\}\
+\
+This links to your 
+\b preference card
+\b0 . It is due on 
+\b Thursday 
+\b0 (September 8) at 
+\b 4PM
+\b0 .\
+\
+After you complete your callbacks (the groups will reach out to you in separate emails with details), it is up to you to fill out your preference card:\
+\
+\pard\tx220\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\li720\fi-720\pardirnatural\partightenfactor0
+\ls1\ilvl0\cf0 {\listtext	1.	}For each group, consider whether or not you would join if they chose to offer you a membership. If you 
+\i would
+\i0  join a specific group, drag their name to the rightmost column ("Attached Groups") or click the plus button. If you 
+\i would not
+\i0  join that group, leave their name in the left column.\
+{\listtext	2.	}This is a 
+\b ranked 
+\b0 list. The name 
+\i highest
+\i0  on this list gets 
+\i first
+\i0  chance to accept you, then the second-highest, and so forth. Order the groups so that the group you would prefer to join 
+\i most
+\i0  is on top. Remember that if 
+\b any
+\b0  group on the right list offers you a membership, you 
+\b MUST
+\b0  accept.\
+{\listtext	3.	}Click 
+\b Submit Preferences
+\b0 .\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+\cf0 \
+This is a 
+\b binding agreement
+\b0  and is 
+\b unchangeable
+\b0  once submitted. If you choose to pref a group and they offer you a membership, you 
+\b MUST
+\b0  accept. If you are unsure, or would prefer not to join a specific group, do 
+\b NOT
+\b0  pref them.\
+\
+If you have any questions, check out the ACAC website (acac.wustl.edu) or email us (acacpresident@gmail.com).\
+\
+Congrats\'97and good luck!\
+Ben Stolovitz\
+ACAC Technical Chair\
+}

--- a/docs/emails/ACAC Acceptance (singular).rtf
+++ b/docs/emails/ACAC Acceptance (singular).rtf
@@ -1,0 +1,73 @@
+{\rtf1\ansi\ansicpg1252\cocoartf1504\cocoasubrtf600
+{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+{\*\expandedcolortbl;\csgray\c100000;}
+{\*\listtable{\list\listtemplateid1\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{decimal\}.}{\leveltext\leveltemplateid1\'02\'00.;}{\levelnumbers\'01;}\fi-360\li720\lin720 }{\listname ;}\listid1}}
+{\*\listoverridetable{\listoverride\listid1\listoverridecount0\ls1}}
+\margl1440\margr1440\vieww13460\viewh16580\viewkind0
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\fs24 \cf0 Hello \{firstname\},\
+\
+Congratulations! You have been offered a callback for an a cappella group at Wash U!\
+\
+
+\b Information: the callback\
+\
+
+\b0 Your callback is with:\
+\
+\{group\}\
+\
+Be prepared for an email with further instructions from them sometime today. \
+\
+This 
+\i callback
+\i0  is 
+\b nonbinding 
+\b0 in any way: if you would prefer not to attend, contact the group. If you attend, but decide you would rather not join this group if accepted, you 
+\i do not have to
+\i0 . That is what your preference card is for:\
+\
+
+\b Action: your preference card\
+\
+
+\b0 \{prefcard link\}\
+\
+This links to your 
+\b preference card
+\b0 . It is due on 
+\b Thursday 
+\b0 (September 8) at 
+\b 4PM
+\b0 . \
+\
+After you complete your callback (the group will reach out to you in a separate email with details), it is up to you to fill out your preference card:\
+\
+\pard\tx220\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\li720\fi-720\pardirnatural\partightenfactor0
+\ls1\ilvl0\cf0 {\listtext	1.	}If you would join this group if they choose to offer you a membership, drag their name to the rightmost column ("Attached Groups") or click the plus button. If you would 
+\i not
+\i0  like to join this group, leave their name in the left column.\
+{\listtext	2.	}Click 
+\b Submit Preferences
+\b0 .\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+\cf0 \
+This 
+\i preference card 
+\i0 is a 
+\b binding agreement 
+\b0 and is 
+\b unchangeable 
+\b0 once submitted. If you choose to pref this group and they offer you a membership, you 
+\b MUST
+\b0  accept. If you are unsure, or would prefer not to join this group, do 
+\b NOT
+\b0  pref them.\
+\
+If you have any questions, check out the ACAC website (acac.wustl.edu) or email us (acacpresident@gmail.com).\
+\
+Congrats\'97and good luck!\
+Ben Stolovitz\
+ACAC Technical Chair}

--- a/docs/emails/ACAC RND2 Acceptance.rtf
+++ b/docs/emails/ACAC RND2 Acceptance.rtf
@@ -1,0 +1,27 @@
+{\rtf1\ansi\ansicpg1252\cocoartf1404\cocoasubrtf470
+{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+\margl1440\margr1440\vieww13500\viewh16580\viewkind0
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\fs24 \cf0 Hello \{firstname\},\
+\
+Congratulations! You have been offered a membership in an a cappella group on campus!\
+\
+You are accepted as a member of \{name of group\}.\
+\
+
+\b Do I need to do anything?
+\b0 \
+\
+No! Since you listed this group on your 
+\b preference card
+\b0 , you are officially a member with no further action needed on your part. Just show up to practice :)\
+\
+We saw an outstanding amount of talent this year, and we are pleased to accept you as part of the a cappella community on campus.\
+\
+Congrats,\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+\cf0 Ben Stolovitz\
+ACAC Technical Chair\
+}

--- a/docs/emails/ACAC RND2 Rejection.rtf
+++ b/docs/emails/ACAC RND2 Rejection.rtf
@@ -1,0 +1,21 @@
+{\rtf1\ansi\ansicpg1252\cocoartf1404\cocoasubrtf470
+{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+\margl1440\margr1440\vieww13500\viewh16580\viewkind0
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\fs24 \cf0 Hello \{firstname\},\
+\
+Thank you for the time, effort, and energy you put into your a cappella auditions and callbacks this semester. We were consistently impressed by the talent and drive apparent in every part of the auditions process. Unfortunately, you are not being offered a membership in the groups you auditioned for this semester.\
+\
+Auditioning for anything takes courage and effort, acceptance or not, and we appreciate the drive, direction, and discipline we saw in all our auditionees and callbackees this year. A cappella is only one aspect of musical performance at Wash U, and this decision is not necessarily a reflection of your overall ability as a singer or musician.\
+\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+\cf0 We encourage you to look into Wash U's School of Music (music.wustl.edu), which has choirs, ensembles, and lessons available for credit, and look into the many other groups on campus involved in music performance.\
+\
+If you have any logistical questions, or further questions about WUSTL a cappella in general, check out acac.wustl.edu and please don't hesitate to contact us at acacpresident@gmail.com.\
+\
+Thank you for your time,\
+Ben Stolovitz\
+ACAC Technical Chair\
+}

--- a/docs/emails/ACAC Rejection.rtf
+++ b/docs/emails/ACAC Rejection.rtf
@@ -1,0 +1,22 @@
+{\rtf1\ansi\ansicpg1252\cocoartf1404\cocoasubrtf470
+{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+\margl1440\margr1440\vieww13460\viewh16580\viewkind0
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\fs24 \cf0 Hello \{firstname\},\
+\
+Thank you for coming out to audition for a cappella at WUSTL. We were overwhelmed by the time and preparation that all 
+\i 210 
+\i0 of you put into your auditions. Unfortunately, you are not being offered a callback to the groups you auditioned for this semester.\
+\
+Auditioning for anything takes courage and effort, and we appreciate the courage, effort, and talent we saw in all our auditionees this year, callback or not. A cappella is only one aspect of musical performance at Wash U, and this decision is not necessarily a reflection of your overall ability as a singer or musician. \
+\
+We encourage you to look into Wash U's School of Music (music.wustl.edu), which has choirs, ensembles, and lessons available for credit, and look into the many other groups on campus involved in music performance.\
+\
+If you have any logistical questions, or further questions about WUSTL a cappella in general, check out acac.wustl.edu and please don't hesitate to contact us at acacpresident@gmail.com.\
+\
+Thank you for your time,\
+Ben Stolovitz\
+ACAC Technical Chair\
+}

--- a/src/Acaplugin/Types/Auditionees.php
+++ b/src/Acaplugin/Types/Auditionees.php
@@ -116,7 +116,7 @@ class Auditionees {
 		}
 		$groups['preferences_submitted'] = array(
 			'name' => 'Preferences Submitted',
-			'desc' => 'Checked if the auditionee has submitted their preferences.',
+			'desc' => 'Checked if the auditionee has submitted their preferences. Uncheck to allow the auditionee to submit preferences again.',
 			'type' => 'checkbox'
 		);
 

--- a/src/BSTypes/src/BSType.php
+++ b/src/BSTypes/src/BSType.php
@@ -396,6 +396,7 @@ class BSType {
 		global $pagenow, $wpdb;
 		if ( is_admin() && 
 			 $pagenow == 'edit.php' &&
+			 array_key_exists('post_type', $_GET) &&
 			 $_GET['post_type'] == $this->get_id() &&
 			 array_key_exists('s', $_GET) ) {
 			$join .= "LEFT JOIN {$wpdb->postmeta} ON " . 
@@ -408,6 +409,7 @@ class BSType {
 		global $pagenow, $wpdb;
 		if ( is_admin() && 
 			 $pagenow == 'edit.php' &&
+			 array_key_exists('post_type', $_GET) &&
 			 $_GET['post_type'] == $this->get_id() &&
 			 array_key_exists('s', $_GET) ) {    
 			 $where = preg_replace(
@@ -422,6 +424,7 @@ class BSType {
 		global $pagenow, $wpdb;
 		if ( is_admin() && 
 			 $pagenow == 'edit.php' &&
+			 array_key_exists('post_type', $_GET) &&
 			 $_GET['post_type'] == $this->get_id() &&
 			 array_key_exists('s', $_GET) ) {    
 			 return 'DISTINCT';


### PR DESCRIPTION
So, it turns out that we've had an "export" feature for auditionees this whole time.

I fixed the documentation to explain how to use that.

I also:

* Added sample email templates
* Improved the in-app documentation for allowing auditionees to re-submit their pref cards.
* Fixed an error that appeared on the "Posts" page.